### PR TITLE
field rma registration cleanups

### DIFF
--- a/include/ghex/structured/bulk_communication_object.hpp
+++ b/include/ghex/structured/bulk_communication_object.hpp
@@ -122,6 +122,8 @@ public: // ctors
                             if (f.domain_id() == p.domain_id())
                             {
                                 auto& source_r = std::get<decltype(i)::value>(m_source_ranges_tuple);
+				// init RMA access for the field before the ranges are created
+				f.init_rma_local();
                                 // loop over elements in index container
                                 for (const auto& c : sit->second)
                                 {

--- a/include/ghex/structured/remote_thread_range.hpp
+++ b/include/ghex/structured/remote_thread_range.hpp
@@ -288,12 +288,11 @@ struct remote_thread_range_generator
         : m_comm{comm}
         , m_guard{}
         , m_view{f, first, last-first+1}
+	, m_local_range{RangeFactory::template create<range_type>(m_view,m_guard)}
         , m_dst{dst}
         , m_tag{tag}
         {
             m_archive.resize(RangeFactory::serial_size);
-            m_view.m_field.init_rma_local();
-	    m_local_range = {RangeFactory::template create<range_type>(m_view,m_guard)};
             RangeFactory::serialize(m_local_range, m_archive.data());
         }
 


### PR DESCRIPTION
initialize the field rma structures before we create the remote ranges. hence only 1 call to `init_rma_local` is made.