### PR TITLE
do not actually link liboomph to libghex: it should be independent of…

### DIFF
--- a/cmake/ghex_oomph.cmake
+++ b/cmake/ghex_oomph.cmake
@@ -20,17 +20,17 @@ if (GHEX_TRANSPORT_BACKEND STREQUAL "LIBFABRIC")
     set(OOMPH_WITH_MPI OFF CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_UCX OFF CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_LIBFABRIC ON CACHE INTERNAL "")  # Forces the value
-    target_link_libraries(ghex PUBLIC oomph::libfabric)
+    target_link_libraries(ghex INTERFACE oomph::libfabric)
 elseif (GHEX_TRANSPORT_BACKEND STREQUAL "UCX")
     set(OOMPH_WITH_MPI OFF CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_UCX ON CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_LIBFABRIC OFF CACHE INTERNAL "")  # Forces the value
-    target_link_libraries(ghex PUBLIC oomph::ucx)
+    target_link_libraries(ghex INTERFACE  oomph::ucx)
 else()
     set(OOMPH_WITH_MPI ON CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_UCX OFF CACHE INTERNAL "")  # Forces the value
     set(OOMPH_WITH_LIBFABRIC OFF CACHE INTERNAL "")  # Forces the value
-    target_link_libraries(ghex PUBLIC oomph::mpi)
+    target_link_libraries(ghex INTERFACE oomph::mpi)
 endif()
 
 if (GHEX_USE_GPU)


### PR DESCRIPTION
… the actual backend.

Right now there are problems when multiple binaries are compiled with different backends, in the same tree. For example, if libghex is linked to oomph_ucx and the actual ghexbenchmark is linked to oomph_mpi, we're in trouble.